### PR TITLE
Add FastAPI RAG backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# chatbot-tienda-alemana-backend
+# Chatbot Tienda Alemana Backend
+
+Este proyecto implementa un backend en **FastAPI** para exponer un sistema de soporte automatizado de la Tienda Alemana. Utiliza un pipeline RAG construido con LangChain, embeddings de `sentence-transformers` y un índice FAISS para recuperar información relevante. El modelo de lenguaje se ejecuta localmente mediante Ollama con el modelo `mistral`.
+
+## Estructura
+
+```
+app/
+├── main.py          # Punto de entrada del servidor
+├── rag_pipeline.py  # Carga del FAISS y generación de respuestas
+├── models.py        # Esquemas Pydantic
+└── config.py        # Configuración
+vector_store/        # Índice FAISS previamente generado (no incluido)
+requirements.txt     # Dependencias
+```
+
+## Uso
+
+1. Crear un entorno virtual y activar.
+2. Instalar dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Ejecutar el servidor:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+4. Hacer solicitudes POST a `http://localhost:8000/ask` con un cuerpo JSON:
+   ```json
+   { "question": "¿Dónde está el arroz de 1kg?" }
+   ```
+
+El servicio responderá con una cadena generada por el modelo.

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,3 @@
+VECTOR_STORE_PATH = "vector_store"
+EMBEDDINGS_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+OLLAMA_MODEL = "mistral"

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+from app.models import QuestionRequest, AnswerResponse
+from app.rag_pipeline import RAGPipeline
+
+app = FastAPI()
+rag = RAGPipeline()
+
+@app.post("/ask", response_model=AnswerResponse)
+def ask_question(req: QuestionRequest) -> AnswerResponse:
+    try:
+        answer = rag.ask(req.question)
+        return AnswerResponse(answer=answer)
+    except Exception as exc:
+        return AnswerResponse(answer=f"Error: {exc}")

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class QuestionRequest(BaseModel):
+    question: str
+
+class AnswerResponse(BaseModel):
+    answer: str

--- a/app/rag_pipeline.py
+++ b/app/rag_pipeline.py
@@ -1,0 +1,22 @@
+from langchain.vectorstores import FAISS
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain_ollama import ChatOllama
+from langchain.chains import RetrievalQA
+
+from app import config
+
+class RAGPipeline:
+    def __init__(self) -> None:
+        embeddings = HuggingFaceEmbeddings(model_name=config.EMBEDDINGS_MODEL)
+        faiss = FAISS.load_local(
+            config.VECTOR_STORE_PATH,
+            embeddings,
+            allow_dangerous_deserialization=True,
+        )
+        retriever = faiss.as_retriever(search_type="similarity", search_kwargs={"k": 4})
+        llm = ChatOllama(model=config.OLLAMA_MODEL)
+        self.qa_chain = RetrievalQA.from_chain_type(llm=llm, retriever=retriever)
+
+    def ask(self, question: str) -> str:
+        result = self.qa_chain.invoke(question)
+        return result["result"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+langchain
+langchain-community
+langchain-huggingface
+langchain-ollama
+sentence-transformers
+faiss-cpu
+pydantic
+tiktoken


### PR DESCRIPTION
## Summary
- implement FastAPI backend with a simple RAG pipeline
- define pydantic models and configuration
- document how to run the server
- add Python requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c82c5d6a4832f9daf26c751a74507